### PR TITLE
Update required openAI version to fix Client.__init__() error in the Streamlit Web App

### DIFF
--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -1,4 +1,4 @@
-openai==1.55.1
+openai==1.56.1
 pydantic==2.10.1
 python-dotenv==1.0.1
 streamlit==1.40.1


### PR DESCRIPTION
With the original specified openAI version, the web app throws the following error: Client.__init__() got an unexpected keyword argument ‘proxies’

See also this discussion in openAI forums: https://community.openai.com/t/client-openai-returns-error-client-init-got-an-unexpected-keyword-argument-proxies/1035249/4

Simply updating the specified openAI version fixes the error.

